### PR TITLE
Add git tagging step to deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,10 @@ jobs:
             source /tmp/venv/openfisca-survey-manager/bin/activate
             .circleci/publish-python-package.sh
 
+      - run:
+          name: Publish a git tag
+          command: .circleci/publish-git-tag.sh
+
 workflows:
   version: 2
   build_and_deploy:


### PR DESCRIPTION
#### Technical changes

- Git tag the deployed package
  - `openfisca-bot` uses `CircleCI` deployment step to git tag `master` branch version
