### PR TITLE
Apply squashed casd patches 2019 05 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.25.0 [#126](https://github.com/openfisca/openfisca-survey-manager/pull/126)
+
+* New features
+- create_data_frame_by_entity is able to handle expressions for filtering (filter_by can be an expression)
+- This allow compute_aggregate and compute_pivot_table to handle expressions as well for filter_by.
+
+* Deprecations
+- Deprecate helper get_entity
+- Deprecate helper get_weights
+
 ## 0.24.0 [#127](https://github.com/openfisca/openfisca-survey-manager/pull/127)
 
 * Fix a bug in create_data_frame_by_entity

--- a/openfisca-survey-manager/patch.txt
+++ b/openfisca-survey-manager/patch.txt
@@ -1,0 +1,1 @@
+Patch à appliquer sur le commit c579a2fccbfbb55445c810461be7b1c1dd3a4e99 de OF-Survey-Manager

--- a/openfisca-survey-manager/patch.txt
+++ b/openfisca-survey-manager/patch.txt
@@ -1,1 +1,0 @@
-Patch à appliquer sur le commit c579a2fccbfbb55445c810461be7b1c1dd3a4e99 de OF-Survey-Manager

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 from typing import Dict, List
 
-import copy
 import logging
 import os
 import numpy as np
@@ -233,7 +232,7 @@ class AbstractSurveyScenario(object):
             for variable in expression_variables:
                 variables.add(variable)
 
-        for variable in variables|set(values):
+        for variable in variables | set(values):
             if variable in tax_benefit_system.variables:
                 assert tax_benefit_system.variables[variable].entity.key == entity_key, \
                     'The variable {} does not belong to entity {}'.format(
@@ -272,12 +271,12 @@ class AbstractSurveyScenario(object):
         if use_baseline_for_columns is not None:
             use_baseline_df = use_baseline_for_columns
         data_frame2 = self.create_data_frame_by_entity(
-                    variables = variables,
-                    period = period,
-                    # use baseline if explicited or when computing difference
-                    use_baseline = use_baseline_df,
-                    index = False
-                    )[entity_key]
+            variables = variables,
+            period = period,
+            # use baseline if explicited or when computing difference
+            use_baseline = use_baseline_df,
+            index = False
+            )[entity_key]
 
         for expression in expressions:
             data_frame2[expression] = data_frame2.eval(expression)
@@ -327,7 +326,6 @@ class AbstractSurveyScenario(object):
         else:
             assert aggfunc == 'count', "Can only use count for aggfunc if no values"
             return data_frame.pivot_table(index = index, columns = columns, values = weight, aggfunc = 'sum')
-
 
     def calculate_variable(self, variable = None, period = None, use_baseline = False):
         """

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -1323,6 +1323,7 @@ def assert_variables_in_same_entity(survey_scenario, variables):
             variables, variable_name, entity.key)
     return entity.key
 
+
 def init_variable_in_entity(simulation, entity, variable_name, series, period):
     variable = simulation.tax_benefit_system.variables[variable_name]
     if series.values.dtype != variable.dtype:

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -178,10 +178,10 @@ class AbstractSurveyScenario(object):
             entity_key = tax_benefit_system.variables[variable].entity.key
             filter_by_entity_key = tax_benefit_system.variables[filter_by_variable].entity.key
             assert filter_by_entity_key == entity_key, \
-                ("You tried to compute agregates for variable '{}', of entity {}"
-                " filtering by variable '{}', of entity {}. This is not possible."
-                " Please choose a filter-by variable of same entity as '{}'."
-                .format(variable, entity_key, filter_by_variable, filter_by_entity_key, variable))
+                ("You tried to compute agregates for variable '{0}', of entity {1}"
+                " filtering by variable '{2}', of entity {3}. This is not possible."
+                " Please choose a filter-by variable of same entity as '{0}'."
+                .format(variable, entity_key, filter_by_variable, filter_by_entity_key))
 
         if self.weight_variable_by_entity:
             weight_variable_by_entity = self.weight_variable_by_entity
@@ -207,13 +207,17 @@ class AbstractSurveyScenario(object):
             filter_dummy = pd.DataFrame({'{}'.format(filter_by_variable): filter_dummy}).eval(filter_by)
 
         if aggfunc == 'sum':
-            return (value * weight * filter_dummy).sum()
+            aggregate = (value * weight * filter_dummy).sum()
         elif aggfunc == 'mean':
-            return (value * weight * filter_dummy).sum() / (weight * filter_dummy).sum()
+            aggregate = (value * weight * filter_dummy).sum() / (weight * filter_dummy).sum()
         elif aggfunc == 'count':
-            return (weight * filter_dummy).sum()
+            aggregate = (weight * filter_dummy).sum()
         elif aggfunc == 'count_non_zero':
-            return (weight * (value != 0) * filter_dummy).sum()
+            aggregate = (weight * (value != 0) * filter_dummy).sum()
+        else:
+            aggregate = None
+
+        return aggregate
 
     def compute_pivot_table(self, aggfunc = 'mean', columns = None, difference = False, filter_by = None, index = None,
             period = None, use_baseline = False, use_baseline_for_columns = None, values = None,
@@ -584,8 +588,7 @@ class AbstractSurveyScenario(object):
                 builder = builder,
                 )
         else:
-            log.info("Invalid period {}".format(period))
-            raise
+            raise ValueError("Invalid period {}".format(period))
 
         return simulation
 

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -1304,19 +1304,6 @@ def assert_variables_in_same_entity(survey_scenario, variables):
             variables, variable_name, entity.key)
     return entity.key
 
-
-def get_entity(survey_scenario, variable):
-    variable_ = survey_scenario.tax_benefit_system.variables.get(variable)
-    assert variable_, 'Variable {} is not part of the tax-benefit-system'.format(variable)
-    return variable_.entity
-
-
-def get_weights(survey_scenario, variable):
-    entity = get_entity(survey_scenario, variable)
-    weight_variable = survey_scenario.weight_variable_by_entity.get(entity.key)
-    return weight_variable
-
-
 def init_variable_in_entity(simulation, entity, variable_name, series, period):
     variable = simulation.tax_benefit_system.variables[variable_name]
     if series.values.dtype != variable.dtype:

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -53,7 +53,7 @@ class AbstractSurveyScenario(object):
     def build_input_data(self, **kwargs):
         NotImplementedError
 
-def calculate_variable(self, variable, period = None, use_baseline = False):
+    def calculate_variable(self, variable, period = None, use_baseline = False):
         """Compute variable values for period and baseline or reform tax benefit and system
 
         :param variable: Variable to compute

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -415,7 +415,25 @@ class AbstractSurveyScenario(object):
 
     def create_data_frame_by_entity(self, variables = None, expressions = None, filter_by = None, index = False,
             period = None, use_baseline = False, merge = False):
+        """Create dataframe(s) of computed variable for every entity (eventually merged in a unique dataframe)
 
+        :param variables: Variable to compute, defaults to None
+        :type variables: list, optional
+        :param expressions: Expressions to compute, defaults to None
+        :type expressions: str, optional
+        :param filter_by: Boolean variable or expression, defaults to None
+        :type filter_by: str, optional
+        :param index: Index by entity id, defaults to False
+        :type index: bool, optional
+        :param period: Period, defaults to None
+        :type period: Period, optional
+        :param use_baseline: Use baseline tax and benefit system, defaults to False
+        :type use_baseline: bool, optional
+        :param merge: Merge all the entities in one data frame, defaults to False
+        :type merge: bool, optional
+        :return: Dictionnary of dataframes by entities or dataframe with all the computed variables
+        :rtype: dict or pandas.DataFrame
+        """
         simulation = self.baseline_simulation if (use_baseline and self.baseline_simulation) else self.simulation
         tax_benefit_system = self.baseline_tax_benefit_system if (
             use_baseline and self.baseline_tax_benefit_system

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -1192,6 +1192,7 @@ class AbstractSurveyScenario(object):
             if holder.variable.definition_period == ETERNITY:
                 array = holder.get_array(ETERNITY)
                 print("permanent: mean = {}, min = {}, max = {}, median = {}, default = {:.1%}".format(
+                    # Need to use float to avoid hit the int16/int32 limit. np.average handles it without conversion
                     array.astype(float).mean() if not weighted else np.average(array, weights = weights),
                     array.min(),
                     array.max(),

--- a/openfisca_survey_manager/surveys.py
+++ b/openfisca_survey_manager/surveys.py
@@ -212,7 +212,7 @@ Contains the following tables : \n""".format(self.name, self.label)
              A DataFrame containing the variables
         """
         assert self.hdf5_file_path is not None
-        assert os.path.exists(self.hdf5_file_path), '{} is not a valid path'.format(
+        assert os.path.exists(self.hdf5_file_path), '{} is not a valid path. This could happen because your data were not builded yet. Please consider using a rebuild option in your code.'.format(
             self.hdf5_file_path)
         store = pandas.HDFStore(self.hdf5_file_path)
 
@@ -220,7 +220,7 @@ Contains the following tables : \n""".format(self.name, self.label)
             df = store.select(table)
         except KeyError:
             log.error('No table {} in the file {}'.format(table, self.hdf5_file_path))
-            log.error('Table(s) available are: {}'.format(store.keys()))
+            log.error('This could happen because your data were not builded yet. Available tables are: {}'.format(store.keys()))
             store.close()
             raise
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '0.24.0',
+    version = '0.25.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
Applying changes for IPP-CASD

#### New features

- create_data_frame_by_entity is able to handle expressions for filtering (`filter_by` can be an expression)
- This allow compute_aggregate and compute_pivot_table to handle expressions as  well for filter_by.
   
#### Deprecations

- Deprecate helper get_entity.
- Deprecate helper get_weights.

Fix #128 