### PR TITLE
Group column dropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 0.31 [#140](https://github.com/openfisca/openfisca-survey-manager/pull/140)
+
+* Group column dropping since DataFrame.drop is expensive.
+
 ### 0.30.1 [#137](https://github.com/openfisca/openfisca-survey-manager/pull/137)
 
 * Fix bug in input data loader
@@ -7,7 +11,7 @@
 ## 0.30.0 [#136](https://github.com/openfisca/openfisca-survey-manager/pull/136)
 
 * Adding description
-*  Adding function documentation.
+* Adding function documentation.
 
 ## 0.29.0 [#134](https://github.com/openfisca/openfisca-survey-manager/pull/134)
 

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -668,7 +668,8 @@ class AbstractSurveyScenario(object):
                 continue
             if column_name not in variables:
                 unknown_columns.append(column_name)
-                input_data_frame.drop(column_name, axis = 1, inplace = True)
+
+        input_data_frame.drop(unknown_columns, axis = 1, inplace = True)
 
         if unknown_columns:
             log.debug('The following unknown columns {}, are dropped from input table'.format(
@@ -687,10 +688,9 @@ class AbstractSurveyScenario(object):
                     continue
 
                 dropped_columns.append(column_name)
-                input_data_frame.drop(column_name, axis = 1, inplace = True)
-                #
-            #
-        #
+
+        input_data_frame.drop(dropped_columns, axis = 1, inplace = True)
+
         if used_columns:
             log.debug(
                 'These columns are not dropped because present in used_as_input_variables:\n {}'.format(

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '0.30.1',
+    version = '0.31',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
Calls to `df.drop` are expensive, grouping them saves a lot of execution time. (About 20% on the IPP benchmark script with 100k individuals). 