### PR TITLE
Coicop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+### 0.35.1 [#149](https://github.com/openfisca/openfisca-survey-manager/pull/149)
+
+* Technical changes
+- Fix deprecation in pandas.
+- Fix stripping of coicop categories
+
 ## 0.35 [#148](https://github.com/openfisca/openfisca-survey-manager/pull/148)
 
 * Introduce some functions to deal with coicop nomenclature

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include openfisca_survey_manager/config_templates *.ini
 include openfisca_survey_manager/tests/data_files/config_template.ini
+recursive-include openfisca_survey_manager/assets

--- a/openfisca_survey_manager/coicop.py
+++ b/openfisca_survey_manager/coicop.py
@@ -33,7 +33,7 @@ def build_coicop_level_nomenclature(level, keep_code = False, to_csv = False):
 
     data_frame.reset_index(inplace = True)
     data_frame.rename(columns = {0: 'code_coicop', 1: 'label_{}'.format(level[:-1])}, inplace = True)
-    data_frame = data_frame.ix[2:].copy()
+    data_frame = data_frame.iloc[2:].copy()
 
     index, stop = 0, False
     for sub_level in sub_levels:

--- a/openfisca_survey_manager/coicop.py
+++ b/openfisca_survey_manager/coicop.py
@@ -50,7 +50,7 @@ def build_coicop_level_nomenclature(level, keep_code = False, to_csv = False):
             stop = True
 
     if keep_code or level == 'postes':
-        data_frame['code_coicop'] = data_frame['code_coicop'].str[1:].copy()
+        data_frame['code_coicop'] = data_frame['code_coicop'].str.lstrip("0")
     else:
         del data_frame['code_coicop']
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '0.35.0',
+    version = '0.35.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### Technical changes

- Use `pandas.DataFrame.iloc` instead of deprecated `.ix` method.
- Fix stripping of coicop categories 
