### PR TITLE
Ajoute un set seed dans mark_weighted_percentiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ﻿# Changelog
 
+### 0.46.8 [#226](https://github.com/openfisca/openfisca-survey-manager/pull/226)
+
+* Technical changes
+- Add a set seed in `mark_weighted_percentiles`, so that when a survey scenario with a baseline and a reform is run, variables which use this function take the same value for a given entity between the baseline and the reform.
+
 ### 0.46.7 [#227](https://github.com/openfisca/openfisca-survey-manager/pull/225)
 
 * Technical changes
 - Handle explicitly SAS related dependecy.
-
 
 ### 0.46.6 [#224](https://github.com/openfisca/openfisca-survey-manager/pull/224)
 

--- a/openfisca_survey_manager/statshelpers.py
+++ b/openfisca_survey_manager/statshelpers.py
@@ -4,6 +4,7 @@ from numpy import argsort, asarray, cumsum, linspace, logical_and as and_, ones,
 import pandas as pd
 import weighted
 import weightedcalcs as wc
+import numpy as np
 
 
 def gini(values, weights = None):
@@ -118,6 +119,8 @@ def mark_weighted_percentiles(a, labels, weights, method, return_quantiles=False
     # The code outputs an array the same shape as 'a', but with
     # labels[i] inserted into spot j if a[j] falls in x-tile i.
     # The number of xtiles requested is inferred from the length of 'labels'.
+
+    np.random.seed(42)
 
     # First method, "vanilla" weights from Wikipedia article.
     if method == 1:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '0.46.7',
+    version = '0.46.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### Technical changes

- Add a set seed in `mark_weighted_percentiles`, so that when a survey scenario with a baseline and a reform is run, variables which use this function take the same value for a given entity between the baseline and the reform.
