### PR TITLE
Fix conda publishing

### DIFF
--- a/.circleci/has-functional-changes.sh
+++ b/.circleci/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/* .conda/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -11,8 +11,10 @@ The CI automaticaly builds the conda package from the [PyPi package](https://pyp
 ## Manual actions made to make it work the first time
 
 - Create an account on https://anaconda.org.
-- Create a token on https://anaconda.org/openfisca/settings/access with _Allow write access to the API site_. Warning, it expires on 2024/02/07.
+- Create a token on https://anaconda.org/openfisca/settings/access with _Allow write access to the API site_.
 - Put the token in a CI environment variable named `ANACONDA_TOKEN`.
+
+⚠️ Warning, the current token expires on 2025/01/14. Check existing tokens and their expiration dates on Anaconda.org website and its [_Access_ section](https://anaconda.org/openfisca/settings/access).
 
 ## Manual actions before initializing the CI
 

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -12,19 +12,19 @@ The CI automaticaly builds the conda package from the [PyPi package](https://pyp
 
 - Create an account on https://anaconda.org.
 - Create a token on https://anaconda.org/openfisca/settings/access with _Allow write access to the API site_. Warning, it expires on 2024/02/07.
-- Put the token in a CI env variable ANACONDA_TOKEN.
+- Put the token in a CI environment variable named `ANACONDA_TOKEN`.
 
-## Manual actions before CI exist
+## Manual actions before initializing the CI
 
-To create the package you can do the following in the project root folder:
+To create a conda package for this repository you can do the following in the project root folder:
 
-- Edit `.conda/meta.yaml` and update it if needed:
+- Edit the `.conda/meta.yaml` and update it if needed with:
     - Version number
     - Hash SHA256
     - Package URL on PyPi
 
-- Build & Upload package:
+- Build & Upload the package:
     - `conda install -c anaconda conda-build anaconda-client`
     - `conda build .conda`
     - `anaconda login`
-    - `anaconda upload openfisca-core-<VERSION>-py_0.tar.bz2`
+    - `anaconda upload openfisca-survey-manager-<VERSION>-py_0.tar.bz2`

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -1,12 +1,12 @@
 # Publish to conda
 
-There is two systems to publish to conda:
-- A fully automatic CI that publish to an _openfisca_ channel. See below for more information.
-- A more complex in Conda-Forge CI, that publish to _Conda-Forge_ channel. See https://www.youtube.com/watch?v=N2XwK9BkJpA for an introduction to Conda-Forge. We do not use it for this project.
+There are two publishing systems for `openfisca-survey-manager` conda packages:
+- A fully automatic CI that publishes to an _openfisca_ channel. See below for more information.
+- A more complex CI calling Conda-Forge CI, that publishes to the _Conda-Forge_ channel. See https://www.youtube.com/watch?v=N2XwK9BkJpA for an introduction to Conda-Forge. We do not use it for this project.
 
 ## Automatic upload
 
-The CI automaticaly build the conda from the PyPi package, and upload it to [anaconda.org](https://anaconda.org/search?q=openfisca) see the `.github/workflow/workflow.yml`, step `publish-to-conda`.
+The CI automaticaly builds the conda package from the [PyPi package](https://pypi.org/project/OpenFisca-Survey-Manager/), and uploads it to [anaconda.org](https://anaconda.org/search?q=openfisca-survey-manager). You can check this out in the GitHub Actions CI file `.github/workflow/workflow.yml` and its `publish-to-conda` step.
 
 ## Manual actions made to make it works the first time
 

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -1,8 +1,8 @@
 # Publish to conda
 
-There are two publishing systems for `openfisca-survey-manager` conda packages:
-- A fully automatic CI that publishes to an _openfisca_ channel. See below for more information.
-- A more complex CI calling Conda-Forge CI, that publishes to the _Conda-Forge_ channel. See https://www.youtube.com/watch?v=N2XwK9BkJpA for an introduction to Conda-Forge. We do not use it for this project.
+There are two publishing systems for openfisca conda packages:
+- A fully automatic CI that publishes to an _openfisca_ channel. `openfisca-survey-manager` conda package is published to this channel. See below for more information.
+- A more complex CI calling Conda-Forge CI, that publishes to the _Conda-Forge_ channel. See https://www.youtube.com/watch?v=N2XwK9BkJpA for an introduction to Conda-Forge. We do not use it for this repository.
 
 ## Automatic upload
 

--- a/.conda/README.md
+++ b/.conda/README.md
@@ -6,12 +6,12 @@ There are two publishing systems for `openfisca-survey-manager` conda packages:
 
 ## Automatic upload
 
-The CI automaticaly builds the conda package from the [PyPi package](https://pypi.org/project/OpenFisca-Survey-Manager/), and uploads it to [anaconda.org](https://anaconda.org/search?q=openfisca-survey-manager). You can check this out in the GitHub Actions CI file `.github/workflow/workflow.yml` and its `publish-to-conda` step.
+The CI automaticaly builds the conda package from the [PyPi package](https://pypi.org/project/OpenFisca-Survey-Manager/), and uploads it to [anaconda.org](https://anaconda.org/search?q=openfisca-survey-manager). You can check this out in the GitHub Actions configuration file `.github/workflow/workflow.yml` and its `publish-to-conda` step.
 
-## Manual actions made to make it works the first time
+## Manual actions made to make it work the first time
 
 - Create an account on https://anaconda.org.
-- Create a token on https://anaconda.org/openfisca/settings/access with _Allow write access to the API site_. Warning, it expire on 2023/01/13.
+- Create a token on https://anaconda.org/openfisca/settings/access with _Allow write access to the API site_. Warning, it expires on 2024/02/07.
 - Put the token in a CI env variable ANACONDA_TOKEN.
 
 ## Manual actions before CI exist

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -11,6 +11,7 @@ package:
   name: {{ name|lower }}
   version: {{ version }}
 
+# openfisca-survey-manager package source
 source:
   url: PYPI_URL
   sha256: PYPI_SHA256

--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -2,7 +2,7 @@
 
 echo "Run has functionnal changes"
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/* .conda/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -136,7 +136,7 @@ jobs:
     if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
-      status: ${{ steps.stop-early.outputs.status }}
+      status: ${{ steps.stop-early.outputs.has_functional_changes_status }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -146,12 +146,12 @@ jobs:
         with:
           python-version: 3.9.9
       - id: stop-early
-        run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "{status}={success}"  >> $GITHUB_STATE ; fi
+        run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "has_functional_changes_status=detected_functional_changes" >> $GITHUB_OUTPUT ; fi
 
   deploy:
     runs-on: ubuntu-20.04
     needs: [ check-for-functional-changes ]
-    if: needs.check-for-functional-changes.outputs.status == 'success'
+    if: needs.check-for-functional-changes.outputs.status == 'detected_functional_changes'
     env:
       PYPI_USERNAME: openfisca-bot
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -204,6 +204,7 @@ jobs:
           conda info
           conda config --set anaconda_upload yes
       - name: Conda build
+        # See .conda/meta.yaml for more information on the built package
         run: conda build --token ${{ secrets.ANACONDA_TOKEN }} --user openfisca .conda
 
   test-on-windows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@
 - Details:
   - Upgrade every dependencies & use their latest versions
 
-### 0.47.2 [#247](https://github.com/openfisca/openfisca-survey-manager/pull/247)
+### 0.47.2 [#249](https://github.com/openfisca/openfisca-survey-manager/pull/249)
 
 * Technical changes
 - Fix `default_config_directory` for use with `openfisca-france-data` in a CI
 
-## 0.47.1 [#246](https://github.com/openfisca/openfisca-survey-manager/pull/246)
+### 0.47.1 [#246](https://github.com/openfisca/openfisca-survey-manager/pull/246)
+
+* Bug fix
+- Debug france data ci (fixes 0.47.0)
+
+## 0.47.0 [#245](https://github.com/openfisca/openfisca-survey-manager/pull/245)
 
 * Technical changes
 - Fix `default_config_directory` for use with `openfisca-france-data` in a CI
@@ -35,7 +40,7 @@
 
 ### 0.46.16
 
-* CI test
+* CI test (no tag)
 
 ### 0.46.15 [#236](https://github.com/openfisca/openfisca-survey-manager/pull/236)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+### [#257](https://github.com/openfisca/openfisca-survey-manager/pull/257)
+
+* Technical changes
+- In GitHub Actions workflow, fixes the `check-for-functional-changes` → **`deploy`** → `publish-to-conda` jobs sequence
+  - Fix the activation of the `deploy` job by fixing how it gets `check-for-functional-changes` output status
+  - Allow the activation of `publish-to-conda` job that needs the `deploy` job
+- Add conda configuration files to non functional files for CI
+
 # 1.0.0 [#252](https://github.com/openfisca/openfisca-survey-manager/pull/252)
 
 * Technical improvement
@@ -40,7 +48,7 @@
 
 ### 0.46.16
 
-* CI test (no tag)
+* CI test
 
 ### 0.46.15 [#236](https://github.com/openfisca/openfisca-survey-manager/pull/236)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-### [#257](https://github.com/openfisca/openfisca-survey-manager/pull/257)
+### 1.0.1 [#257](https://github.com/openfisca/openfisca-survey-manager/pull/257)
 
 * Technical changes
 - In GitHub Actions workflow, fixes the `check-for-functional-changes` → **`deploy`** → `publish-to-conda` jobs sequence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,41 @@
 
 # 1.0.0 [#252](https://github.com/openfisca/openfisca-survey-manager/pull/252)
 
-* Technical improvement.
-- Impacted periods: all.
-- Impacted areas: all.
-- Details:
-  - Upgrade every dependencies & use their latest versions
+* Technical improvement
+  - Impacted periods: all.
+  - Impacted areas: all.
+  - Details:
+    - Upgrade every dependencies & use their latest versions
 
 ### 0.47.2 [#249](https://github.com/openfisca/openfisca-survey-manager/pull/249)
 
 * Technical changes
-- Fix `default_config_directory` for use with `openfisca-france-data` in a CI
+  - Fix `default_config_directory` for use with `openfisca-france-data` in a CI
 
 ### 0.47.1 [#246](https://github.com/openfisca/openfisca-survey-manager/pull/246)
 
 * Bug fix
-- Debug france data ci (fixes 0.47.0)
+  - Debug france data ci (fixes 0.47.0)
 
 ## 0.47.0 [#245](https://github.com/openfisca/openfisca-survey-manager/pull/245)
 
 * Technical changes
-- Fix `default_config_directory` for use with `openfisca-france-data` in a CI
+  - Fix `default_config_directory` for use with `openfisca-france-data` in a CI
 
 ### 0.46.19 [#244](https://github.com/openfisca/openfisca-survey-manager/pull/244)
 
 * Technical changes
-- Bump to publish package
+  - Bump to publish package
 
 ### 0.46.18 [#243](https://github.com/openfisca/openfisca-survey-manager/pull/243)
 
 * Technical changes
-- Bump to publish package
+  - Bump to publish package
 
 ### 0.46.17 [#242](https://github.com/openfisca/openfisca-survey-manager/pull/242)
 
 * Technical changes
-- Fix bug in `SurveyCollection.load`
+  - Bug fix in `SurveyCollection.load`
 
 ### 0.46.16
 
@@ -45,145 +45,145 @@
 ### 0.46.15 [#236](https://github.com/openfisca/openfisca-survey-manager/pull/236)
 
 * Technical changes
-- Put back test in CI
-- Fix coveralls config fot GitHub Actions
-- Add a test for create_data_frame_by_entity
-- Bump Actions and Python version to fix warnings
+  - Put back test in CI
+  - Fix coveralls config fot GitHub Actions
+  - Add a test for create_data_frame_by_entity
+  - Bump Actions and Python version to fix warnings
 
 ### 0.46.14 [#234](https://github.com/openfisca/openfisca-survey-manager/pull/234)
 
 * Technical changes
-- Convert every cells of a column to string.
+  - Convert every cells of a column to string.
 
 ### 0.46.13 [#233](https://github.com/openfisca/openfisca-survey-manager/pull/233)
 
 * Technical changes
-- Correcting the code asking for the period before it's instated
-- Checking the new period assignment
+  - Correcting the code asking for the period before it's instated
+  - Checking the new period assignment
 
 ### 0.46.12 [#232](https://github.com/openfisca/openfisca-survey-manager/pull/232)
 
 * Technical changes
-- Deal with Nan in Enum variables
+  - Deal with Nan in Enum variables
 
 ### 0.46.11 [#227](https://github.com/openfisca/openfisca-survey-manager/pull/227)
 
 * Technical changes
-- Add build of a tar.gz
-- Add a make entry for build
-- Move CI from Circle CI to GitHub Action (Except `make test` that run only on CircleCI)
+  - Add build of a tar.gz
+  - Add a make entry for build
+  - Move CI from Circle CI to GitHub Action (Except `make test` that run only on CircleCI)
 
 ### 0.46.10 [#229](https://github.com/openfisca/openfisca-survey-manager/pull/229)
 
 * Technical changes
-- Add tar.gz to PyPi
-- Add display readme to PyPi
+  - Add tar.gz to PyPi
+  - Add display readme to PyPi
 
 ### 0.46.9 [#228](https://github.com/openfisca/openfisca-survey-manager/pull/228)
 
 * Technical changes
-- Refactor tables method to mutualize code
-- Save variables in table survey data
+  - Refactor tables method to mutualize code
+  - Save variables in table survey data
 
 ### 0.46.8 [#226](https://github.com/openfisca/openfisca-survey-manager/pull/226)
 
 * Technical changes
-- Add a set seed in `mark_weighted_percentiles`, so that when a survey scenario with a baseline and a reform is run, variables which use this function take the same value for a given entity between the baseline and the reform.
+  - Add a set seed in `mark_weighted_percentiles`, so that when a survey scenario with a baseline and a reform is run, variables which use this function take the same value for a given entity between the baseline and the reform.
 
 ### 0.46.7 [#227](https://github.com/openfisca/openfisca-survey-manager/pull/225)
 
 * Technical changes
-- Handle explicitly SAS related dependecy.
+  - Handle explicitly SAS related dependecy.
 
 ### 0.46.6 [#224](https://github.com/openfisca/openfisca-survey-manager/pull/224)
 
 * Bug fix
-- Using pyreadstat instead of SAS7BDAT which is no more the canonical way to read sas files into pandas dataframes.
+  - Using pyreadstat instead of SAS7BDAT which is no more the canonical way to read sas files into pandas dataframes.
 
 ### 0.46.5 [#223](https://github.com/openfisca/openfisca-survey-manager/pull/223)
 
 * Bug fix
-- Deal with HDF5 file opening strict policy in build-collection
+  - Deal with HDF5 file opening strict policy in build-collection
 
 ### 0.46.4 [#219](https://github.com/openfisca/openfisca-survey-manager/pull/219)
 
 * Technical changes
-- Better handling of CategoricalDtype in input data
+  - Better handling of CategoricalDtype in input data
 
 ### 0.46.3 [#217](https://github.com/openfisca/openfisca-survey-manager/pull/217)
 
 * Bug fix
-- Deal with HDF5 file opening strict policy
+  - Deal with HDF5 file opening strict policy
 
 ### 0.46.2 [#214](https://github.com/openfisca/openfisca-survey-manager/pull/214)
 
 * New features
-- Introduce AbsstractSurveyScenario.calculate_series
+  - Introduce AbsstractSurveyScenario.calculate_series
 
 ### 0.46.1 [#211](https://github.com/openfisca/openfisca-survey-manager/pull/211)
 
 * Technical changes
-- Improve dialect detection for csv files
+  - Improve dialect detection for csv files
 
 ## 0.46 [#210](https://github.com/openfisca/openfisca-survey-manager/pull/210)
 
 * Technical changes
-- Hack to deal with encodings and delimiter not detected by pandas.read_csv
+  - Hack to deal with encodings and delimiter not detected by pandas.read_csv
 
 ## 0.45 [#143](https://github.com/openfisca/openfisca-survey-manager/pull/143)
 
 * Technical changes
-- In compute_marginal_tax_rate allow for automatic aggregation on group entity when target and varying variables entity are not the same and the varying variable entity is a person one.
+  - In compute_marginal_tax_rate allow for automatic aggregation on group entity when target and varying variables entity are not the same and the varying variable entity is a person one.
 
 ### 0.44.2 [#208](https://github.com/openfisca/openfisca-survey-manager/pull/208)
 
-* Fix bug:
-- Fix typo.
+* Bug fix
+  - Fix typo.
 
 ### 0.44.1 [#207](https://github.com/openfisca/openfisca-survey-manager/pull/207)
 
-* Fix bug:
-- Fix aggregates export to html.
+* Bug fix
+  - Fix aggregates export to html.
 
 ## 0.44 [#206](https://github.com/openfisca/openfisca-survey-manager/pull/206)
 
-* New feature:
-- Ability to export aggregates to html.
+* New feature
+  - Ability to export aggregates to html.
 
 ## 0.43 [#135](https://github.com/openfisca/openfisca-survey-manager/pull/135)
 
-* New feature:
-- Introduce aggregates.
+* New feature
+  - Introduce aggregates.
 
 ### 0.42.3 [#189](https://github.com/openfisca/openfisca-survey-manager/pull/189)
 
 * Technical changes
-- Accept categorical columns in input data frames to initialize Enum variables.
+  - Accept categorical columns in input data frames to initialize Enum variables.
 
 ### 0.42.2 [#204](https://github.com/openfisca/openfisca-survey-manager/pull/204)
 
 * Technical changes
-- Add on sub-periods when creating a quantile on a larger period
+  - Add on sub-periods when creating a quantile on a larger period
 
 ### 0.42.1 [#200](https://github.com/openfisca/openfisca-survey-manager/pull/200)
 
-* Fix bug:
-- Let numpy dependence come from openfisca-core
+* Bug fix
+  - Let numpy dependence come from openfisca-core
 
 ### 0.42.0 [#198](https://github.com/openfisca/openfisca-survey-manager/pull/198)
 
-* New feature:
-- Allow to build collections/surveys from csv files
+* New feature
+  - Allow to build collections/surveys from csv files
 
 ### 0.41.3 [#196](https://github.com/openfisca/openfisca-survey-manager/pull/196)
 
 * Bug fix
-- Enforce HDF store closing when done
+  - Enforce HDF store closing when done
 
 ### 0.41.2 [#194](https://github.com/openfisca/openfisca-survey-manager/pull/194)
 
 * Bug fix
-- Enforce us of np.array for weights and filters when computing aggregates
+  - Enforce us of np.array for weights and filters when computing aggregates
 
 ### 0.41.1 [#187](https://github.com/openfisca/openfisca-survey-manager/pull/187)
 
@@ -191,28 +191,28 @@
 ### 0.41.0 [#185](https://github.com/openfisca/openfisca-survey-manager/pull/186)
 
 * New features
+  - Add a method to compute quantile
+  - Extend the computation of marginal tax rate
 
-- Add a method to compute quantile
-- Extend the computation of marginal tax rate
 ### 0.40.1 [#185](https://github.com/openfisca/openfisca-survey-manager/pull/185)
 
 * Technical improvement
-- Introduce weighted option in `compute_aggregate` and `compute_pivot_table`
-- Change `weights` to `alternative_weights` in `compute_aggregate` and `compute_pivot_table`
+  - Introduce weighted option in `compute_aggregate` and `compute_pivot_table`
+  - Change `weights` to `alternative_weights` in `compute_aggregate` and `compute_pivot_table`
 
 ### 0.40.0 [#184](https://github.com/openfisca/openfisca-survey-manager/pull/184)
 
 * Technical improvement
-- Add weights keyword argument to `compute_aggregate` and `compute_pivot_table`
+  - Add weights keyword argument to `compute_aggregate` and `compute_pivot_table`
 
 * Improve documentation
-- Use googl style in docstring
-- Add some docstring
+  - Use googl style in docstring
+  - Add some docstring
 
 ### 0.39.1 [#178](https://github.com/openfisca/openfisca-survey-manager/pull/178)
 
 * Bug fix
-- Fix inflate that inflated twice when baseline_simulation == simulation
+  - Fix inflate that inflated twice when baseline_simulation == simulation
 
 ### 0.39.0 [#170](https://github.com/openfisca/openfisca-survey-manager/pull/170)
 
@@ -232,52 +232,52 @@
 
 ## 0.38.0 [#156](https://github.com/openfisca/openfisca-survey-manager/pull/156)
 
-##### New features
-- Introduce `survey_scenario.generate_performance_data(output_dir)`
-  - This generates a performance graph and CSV tables containing details about execution times of OpenFisca formulas
+* New features
+  - Introduce `survey_scenario.generate_performance_data(output_dir)`
+    - This generates a performance graph and CSV tables containing details about execution times of OpenFisca formulas
 
 ### 0.37.3 [#157](https://github.com/openfisca/openfisca-survey-manager/pull/157)
 
 * Technical changes
-- Add `tables` library to default requirements
+  - Add `tables` library to default requirements
 * Add documentation for users installing, configuring and running the module for the first time
 
 ### 0.37.2 [#155](https://github.com/openfisca/openfisca-survey-manager/pull/155)
 
 * Technical changes
-- Improve error mesage in build_collection (fix previous version)
+  - Improve error mesage in build_collection (fix previous version)
 
 ### 0.37.1 [#154](https://github.com/openfisca/openfisca-survey-manager/pull/154)
 
 * Technical changes
-- Improve error mesage in build_collection
+  - Improve error mesage in build_collection
 
 ## 0.37.0
 
 * Technical changes
-- Add ignorecase argument to Survey.get_values
+  - Add ignorecase argument to Survey.get_values
 
 ### 0.36.3 [#152](https://github.com/openfisca/openfisca-survey-manager/pull/152)
 
 * Technical changes
-- Fix asof for `TaxScale`
-- Use `simulation.get_known_periods` instead of `Holder`'s method in `summariaze_variable`
+  - Fix asof for `TaxScale`
+  - Use `simulation.get_known_periods` instead of `Holder`'s method in `summariaze_variable`
 
 ## 0.36.0 [#152](https://github.com/openfisca/openfisca-survey-manager/pull/152)
 
 * Technical changes
-- Create collections directory when it is missing
+  - Create collections directory when it is missing
 
 ### 0.35.2 [#150](https://github.com/openfisca/openfisca-survey-manager/pull/150)
 
 * Technical changes
-- Fix assets inclusion
+  - Fix assets inclusion
 
 ### 0.35.1 [#149](https://github.com/openfisca/openfisca-survey-manager/pull/149)
 
 * Technical changes
-- Fix deprecation in pandas.
-- Fix stripping of coicop categories
+  - Fix deprecation in pandas.
+  - Fix stripping of coicop categories
 
 ## 0.35 [#148](https://github.com/openfisca/openfisca-survey-manager/pull/148)
 
@@ -315,7 +315,7 @@
 ## 0.29.0 [#134](https://github.com/openfisca/openfisca-survey-manager/pull/134)
 
 * New features
-- Introduce compute_marginal_tax_rate.
+  - Introduce compute_marginal_tax_rate.
 
 ## 0.28.0 [#133](https://github.com/openfisca/openfisca-survey-manager/pull/133)
 
@@ -326,24 +326,24 @@
 ## 0.27.0 [#132](https://github.com/openfisca/openfisca-survey-manager/pull/132)
 
 * Technical changes
-- Fix create_data_frame_by_entity
-- Fix some deprecations
+  - Fix create_data_frame_by_entity
+  - Fix some deprecations
 
 ## 0.26.0
 
 * New features
-- Neutralized variables are now correctly handled by summarize_variable
-- Extend testing to doctest
+  - Neutralized variables are now correctly handled by summarize_variable
+  - Extend testing to doctest
 
 ## 0.25.0 [#126](https://github.com/openfisca/openfisca-survey-manager/pull/126)
 
 * New features
-- create_data_frame_by_entity is able to handle expressions for filtering (filter_by can be an expression)
-- This allow compute_aggregate and compute_pivot_table to handle expressions as well for filter_by.
+  - create_data_frame_by_entity is able to handle expressions for filtering (filter_by can be an expression)
+  - This allow compute_aggregate and compute_pivot_table to handle expressions as well for filter_by.
 
 * Deprecations
-- Deprecate helper get_entity
-- Deprecate helper get_weights
+  - Deprecate helper get_entity
+  - Deprecate helper get_weights
 
 ## 0.24.0 [#127](https://github.com/openfisca/openfisca-survey-manager/pull/127)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '1.0.0',
+    version = '1.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
✅ ~~⚠️ The `TO REVERT` commits should be squashed and removed before merging this PR.~~

#### Technical changes

- In GitHub Actions workflow, fixes the `check-for-functional-changes` → **`deploy`** → `publish-to-conda` jobs sequence
  - Fix the activation of the `deploy` job by fixing how it gets `check-for-functional-changes` output status
  - Allow the activation of `publish-to-conda` job that needs the `deploy` job
- Add conda configuration files to non functional files for CI

#### Minor changes

- In `.conda/README.md`, update the `ANACONDA_TOKEN` expiration date and document additional links
- Fix `0.47.*` revisions description in CHANGELOG and format file
  
- - - -

#### How we fix the activation of the `deploy` job by fixing how it gets `check-for-functional-changes` output status

On [the latest CI for `master` branch](https://github.com/openfisca/openfisca-survey-manager/actions/runs/5213270267) we see that the `deploy` job was skipped and that no output is given for the previous `check-for-functional-changes` job (`Complete job` only says : `Evaluate and set job outputs` / `Cleaning up orphan processes`).

We were using `$GITHUB_STATE` variable to store the job output. This PR changes the variable name as [GitHub Actions documentation advises for `$GITHUB_OUTPUT` variable](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs).

These variables were used as a new syntax for save-state and set-output old commands and the [migration blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) gives `{variable}={value}` syntax but the curly brackets only mean that the full word should be replaced. This PR removes the curly brackets (we see on the [tmp-check job of the 199th workflow](https://github.com/openfisca/openfisca-survey-manager/actions/runs/5456811979/jobs/9930119954) that the 'status' appears and that the [202th workflow that tmp-debug job is for the first time not skipped](https://github.com/openfisca/openfisca-survey-manager/actions/runs/5456842083/jobs/9930191378) when we remove the quotation marks).

#### How we fix the `check-for-functional-changes`

On this PR `fix-conda-publishing` branch and before updating the repository tags we had: 
```shell
$ sh .github/has-functional-changes.sh 
Run has functionnal changes
.conda/README.md
.conda/meta.yaml
CHANGELOG.md
openfisca_survey_manager/__init__.py
openfisca_survey_manager/aggregates.py
openfisca_survey_manager/calmar.py
openfisca_survey_manager/coicop.py
openfisca_survey_manager/config.py
openfisca_survey_manager/matching.py
openfisca_survey_manager/read_sas.py
openfisca_survey_manager/read_spss.py
openfisca_survey_manager/scenarios.py
openfisca_survey_manager/scripts/build_collection.py
openfisca_survey_manager/statshelpers.py
openfisca_survey_manager/survey_collections.py
openfisca_survey_manager/temporary.py
openfisca_survey_manager/tests/data_files/test_random_generator.json
openfisca_survey_manager/tests/test_add_survey_to_collection.py
openfisca_survey_manager/tests/test_create_data_frame_by_entity.py
openfisca_survey_manager/tests/test_matching.py
openfisca_survey_manager/tests/test_read_sas.py
openfisca_survey_manager/tests/test_scenario.py
setup.cfg
setup.py
The functional files above were changed.
```

This happened because the `deploy` job was broken is CI, multiple tags were missing. So the script was listing all the diff between the `0.46.14` revision and this branch. 

Knowing that newer tags existed but were not verified, the tags were updated as follows:

<table>
  <tr><td>TAGS BEFORE FIX</td><td>TAGS AFTER FIX</td></tr>
 <tr><td>
<img width="1128" alt="Capture d’écran 2023-07-06 à 14 28 42" src="https://github.com/openfisca/openfisca-survey-manager/assets/6567910/83e4adfb-3a3e-4d10-a05a-b09c9ddaf3ad">
</td><td>
<img width="852" alt="Capture d’écran 2023-07-06 à 14 49 31" src="https://github.com/openfisca/openfisca-survey-manager/assets/6567910/1afb1a53-ec30-4789-8b42-abd53bc80334">
</td></tr>
</table>

> `0.46.15` wasn't on the `master` branch commit so its reference commit was changed.
> `0.46.16` isn't on the `master` branch but is kept as is as it looks like a manual CI test without pull request.