### PR TITLE
Generalize config path

### DIFF
--- a/openfisca_survey_manager/input_dataframe_generator.py
+++ b/openfisca_survey_manager/input_dataframe_generator.py
@@ -180,14 +180,17 @@ def randomly_init_variable(tax_benefit_system, input_dataframe_by_entity, variab
 
 
 def set_table_in_survey(input_dataframe, entity, period, collection, survey_name, survey_label = None,
-        table_label = None, table_name = None):
+        table_label = None, table_name = None, config_files_directory = None):
     period = periods.period(period)
     if table_name is None:
         table_name = entity + '_' + str(period)
     if table_label is None:
         table_label = "Input data for entity {} at period {}".format(entity, period)
     try:
-        survey_collection = SurveyCollection.load(collection = collection)
+        if config_files_directory:
+            survey_collection = SurveyCollection.load(collection = collection, config_files_directory=config_files_directory)
+        else:
+            survey_collection = SurveyCollection.load(collection = collection)
     except configparser.NoOptionError:
         survey_collection = SurveyCollection(name = collection)
     except configparser.NoSectionError:  # For tests

--- a/openfisca_survey_manager/survey_collections.py
+++ b/openfisca_survey_manager/survey_collections.py
@@ -103,13 +103,13 @@ Contains the following surveys :
             try:
                 json_file_path = config.get("collections", collection)
             except Exception as error:
-                log.debug("Looking for congi file in {}".format(config_files_directory))
+                log.debug("Looking for config file in {}".format(config_files_directory))
                 log.error(error)
                 raise
 
         with open(json_file_path, 'r') as _file:
             self_json = json.load(_file)
-            name = self_json.get('name')
+            name = self_json['name']  # Better than .get as it will raise an error if key don't exist.
 
         self = cls(name = name)
         self.config = config

--- a/openfisca_survey_manager/tests/test_add_survey_to_collection.py
+++ b/openfisca_survey_manager/tests/test_add_survey_to_collection.py
@@ -35,3 +35,12 @@ def test_add_survey_to_collection():
         )
     ordered_dict = survey_collection.to_json()
     assert survey_name in list(ordered_dict['surveys'].keys())
+
+    # Read survey
+    survey_collection = SurveyCollection.load(config_files_directory = data_dir, collection=name)
+    survey = survey_collection.get_survey(survey_name)
+    table = survey.get_values(
+        table="help", ignorecase=True
+        )
+    print(len(table))
+    assert len(table) == 10

--- a/openfisca_survey_manager/tests/test_add_survey_to_collection.py
+++ b/openfisca_survey_manager/tests/test_add_survey_to_collection.py
@@ -2,10 +2,11 @@
 
 import os
 import pkg_resources
-
+import pandas as pd
 
 from openfisca_survey_manager.survey_collections import SurveyCollection
 from openfisca_survey_manager.scripts.build_collection import add_survey_to_collection
+from openfisca_survey_manager.input_dataframe_generator import set_table_in_survey
 
 # Travis, Gitlab runner, Gihub Action and circle has env variable "CI" set by default
 if 'CI' in os.environ:
@@ -15,8 +16,8 @@ else:
 
 
 def test_add_survey_to_collection():
-    if is_in_ci:
-        return
+    # if is_in_ci:
+    #     return
     name = 'fake'
     survey_name = 'fake_survey'
     data_dir = os.path.join(
@@ -36,11 +37,59 @@ def test_add_survey_to_collection():
     ordered_dict = survey_collection.to_json()
     assert survey_name in list(ordered_dict['surveys'].keys())
 
+
+def test_set_table_in_survey_first_year():
+    data_dir = os.path.join(
+        pkg_resources.get_distribution('openfisca-survey-manager').location,
+        'openfisca_survey_manager/tests/data_files',
+        )
+    input_dataframe = pd.DataFrame({"rfr": [1_000, 2_000, 100_000]})
+    survey_name = 'test_set_table_in_survey_2020'
+    collection = "fake"
+    set_table_in_survey(input_dataframe, entity="foyer", period="2020", collection = collection, survey_name = survey_name, config_files_directory=data_dir)
+
     # Read survey
-    survey_collection = SurveyCollection.load(config_files_directory = data_dir, collection=name)
+    survey_collection = SurveyCollection.load(config_files_directory = data_dir, collection=collection)
     survey = survey_collection.get_survey(survey_name)
     table = survey.get_values(
-        table="help", ignorecase=True
+        table="foyer_2020", ignorecase=True
         )
     print(len(table))
-    assert len(table) == 10
+    assert len(table) == 3
+    assert table.columns == ["rfr"]
+    assert table.rfr.sum() == 103000
+
+
+def test_set_table_in_survey_second_year():
+    data_dir = os.path.join(
+        pkg_resources.get_distribution('openfisca-survey-manager').location,
+        'openfisca_survey_manager/tests/data_files',
+        )
+    input_dataframe = pd.DataFrame({"rfr": [1_021, 2_021, 100_021]})
+    survey_name = 'test_set_table_in_survey_2021'
+    collection = "fake"
+    set_table_in_survey(input_dataframe, entity="foyer", period="2021", collection = collection, survey_name = survey_name, config_files_directory=data_dir)
+
+    # Read first survey
+    survey_name = 'test_set_table_in_survey_2020'
+    survey_collection = SurveyCollection.load(config_files_directory = data_dir, collection=collection)
+    survey = survey_collection.get_survey(survey_name)
+    table = survey.get_values(
+        table="foyer_2020", ignorecase=True
+        )
+    print(len(table))
+    assert len(table) == 3
+    assert table.columns == ["rfr"]
+    assert table.rfr.sum() == 103000
+
+    # Read second survey
+    survey_name = 'test_set_table_in_survey_2021'
+    survey_collection = SurveyCollection.load(config_files_directory = data_dir, collection=collection)
+    survey = survey_collection.get_survey(survey_name)
+    table = survey.get_values(
+        table="foyer_2021", ignorecase=True
+        )
+    print(len(table))
+    assert len(table) == 3
+    assert table.columns == ["rfr"]
+    assert table.rfr.sum() == 103063

--- a/openfisca_survey_manager/tests/test_add_survey_to_collection.py
+++ b/openfisca_survey_manager/tests/test_add_survey_to_collection.py
@@ -3,6 +3,7 @@
 import os
 import pkg_resources
 import pandas as pd
+import pytest
 
 from openfisca_survey_manager.survey_collections import SurveyCollection
 from openfisca_survey_manager.scripts.build_collection import add_survey_to_collection
@@ -38,7 +39,10 @@ def test_add_survey_to_collection():
     assert survey_name in list(ordered_dict['surveys'].keys())
 
 
+@pytest.mark.order(after="test_surveys.py::test_survey")
 def test_set_table_in_survey_first_year():
+    # if is_in_ci:
+    #     return
     data_dir = os.path.join(
         pkg_resources.get_distribution('openfisca-survey-manager').location,
         'openfisca_survey_manager/tests/data_files',
@@ -60,7 +64,10 @@ def test_set_table_in_survey_first_year():
     assert table.rfr.sum() == 103000
 
 
+@pytest.mark.order(after="test_set_table_in_survey_first_year")
 def test_set_table_in_survey_second_year():
+    # if is_in_ci:
+    #     return
     data_dir = os.path.join(
         pkg_resources.get_distribution('openfisca-survey-manager').location,
         'openfisca_survey_manager/tests/data_files',

--- a/openfisca_survey_manager/tests/test_add_survey_to_collection.py
+++ b/openfisca_survey_manager/tests/test_add_survey_to_collection.py
@@ -58,7 +58,6 @@ def test_set_table_in_survey_first_year():
     table = survey.get_values(
         table="foyer_2020", ignorecase=True
         )
-    print(len(table))
     assert len(table) == 3
     assert table.columns == ["rfr"]
     assert table.rfr.sum() == 103000
@@ -84,7 +83,6 @@ def test_set_table_in_survey_second_year():
     table = survey.get_values(
         table="foyer_2020", ignorecase=True
         )
-    print(len(table))
     assert len(table) == 3
     assert table.columns == ["rfr"]
     assert table.rfr.sum() == 103000
@@ -96,7 +94,6 @@ def test_set_table_in_survey_second_year():
     table = survey.get_values(
         table="foyer_2021", ignorecase=True
         )
-    print(len(table))
     assert len(table) == 3
     assert table.columns == ["rfr"]
     assert table.rfr.sum() == 103063


### PR DESCRIPTION
#### New features

- There is a `config_files_directory` parameter but not evrywhere, this PR generalize it. This allow to do not store config in user home directory as the actual behavior.

#### Precision
Note about `fake.json` : this file is created by `openfisca_survey_manager/tests/test_surveys.py` and then used by `openfisca_survey_manager/tests/test_add_survey_to_collection.py`

To test it locally, you have to do export `CI=True`, so that it use the config in `openfisca_survey_manager/tests/data_files` instead of you home.