### PR TITLE
Improve inflate parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ﻿# Changelog
 
+### 1.0.3 [#260](https://github.com/openfisca/openfisca-survey-manager/pull/260)
+
+* New features
+
+- Add options in inflate_parameters and inflate_parameter_leaf:
+  - start_update_instant : Instant of the year when the inflation should start, if different from January 1st
+  - round_ndigits : number of digits in the rounded result
+- Adjustment of inflate_parameters to use it with parameter leaf
+
 ### 1.0.2 [#259](https://github.com/openfisca/openfisca-survey-manager/pull/259)
 
 * Technical changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-### 1.0.3 [#260](https://github.com/openfisca/openfisca-survey-manager/pull/260)
+### 1.1.0 [#260](https://github.com/openfisca/openfisca-survey-manager/pull/260)
 
 * New features
 

--- a/openfisca_survey_manager/tests/test_legislation_inflator.py
+++ b/openfisca_survey_manager/tests/test_legislation_inflator.py
@@ -83,6 +83,26 @@ def test_inflate_scale_with_changing_number_of_brackets():
             threshold_2017, threshold_2016 * 1.3
             )
 
+def test_inflate_start_instant_option():
+    """
+        Test parameters inflator with a specific start_instant
+    """
+    tax_benefit_system = CountryTaxBenefitSystem()
+    parameters = tax_benefit_system.parameters
+    parameters_asof(parameters, instant = periods.instant(2022))  # Remove post 2016 legislation changes
+    inflate_parameters(parameters, inflator = .3, base_year = 2022, last_year = 2023, start_instant="2023-07-01")
+    for (threshold_2023_06, threshold_2023_07, threshold_2022) in zip(
+            parameters.taxes.social_security_contribution('2023-06').thresholds,
+            parameters.taxes.social_security_contribution('2023-07').thresholds,
+            parameters.taxes.social_security_contribution(2022).thresholds
+            ):
+        assert threshold_2023_07 == threshold_2022 * 1.3, "{} != {}".format(
+            threshold_2023_07, threshold_2022 * 1.3
+            )
+        assert threshold_2023_06 == threshold_2022, "{} != {}".format(
+            threshold_2023_06, threshold_2022
+            )
+
 
 if __name__ == '__main__':
     test_inflate_simple_parameter()
@@ -90,3 +110,4 @@ if __name__ == '__main__':
     test_inflate_scale_with_changing_number_of_brackets()
     test_asof_simple_annual_parameter()
     test_asof_scale_parameters()
+    test_inflate_start_instant_option()

--- a/openfisca_survey_manager/tests/test_legislation_inflator.py
+++ b/openfisca_survey_manager/tests/test_legislation_inflator.py
@@ -90,7 +90,7 @@ def test_inflate_start_instant_option():
     """
     tax_benefit_system = CountryTaxBenefitSystem()
     parameters = tax_benefit_system.parameters
-    parameters_asof(parameters, instant = periods.instant(2022))  # Remove post 2016 legislation changes
+    parameters_asof(parameters, instant = periods.instant(2022))  # Remove post 2022 legislation changes
     inflate_parameters(parameters, inflator = .3, base_year = 2022, last_year = 2023, start_instant="2023-07-01")
     for (threshold_2023_06, threshold_2023_07, threshold_2022) in zip(
             parameters.taxes.social_security_contribution('2023-06').thresholds,

--- a/openfisca_survey_manager/tests/test_legislation_inflator.py
+++ b/openfisca_survey_manager/tests/test_legislation_inflator.py
@@ -83,6 +83,7 @@ def test_inflate_scale_with_changing_number_of_brackets():
             threshold_2017, threshold_2016 * 1.3
             )
 
+
 def test_inflate_start_instant_option():
     """
         Test parameters inflator with a specific start_instant

--- a/openfisca_survey_manager/utils.py
+++ b/openfisca_survey_manager/utils.py
@@ -26,7 +26,7 @@ def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore
     """
 
     if (last_year is not None) and (last_year > base_year + 1):
-        for year in range(base_year + 1, last_year + 1): # For each year we inflate with the same inflator rate. Example : base_year + 1 : paramaters = paramaters * inflator ; base_year + 2 : parameters = parameters * inflator * inflator
+        for year in range(base_year + 1, last_year + 1):  # For each year we inflate with the same inflator rate. Example : base_year + 1 : paramaters = paramaters * inflator ; base_year + 2 : parameters = parameters * inflator * inflator
             inflate_parameters(parameters, inflator, year - 1, last_year = year, ignore_missing_units = ignore_missing_units,
                                start_instant = start_instant, round_ndigits = round_ndigits)
 

--- a/openfisca_survey_manager/utils.py
+++ b/openfisca_survey_manager/utils.py
@@ -25,39 +25,37 @@ def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore
             last_year = base_year + 1
 
         assert last_year == base_year + 1
-
-        for sub_parameter in parameters.children.values():
-            if isinstance(sub_parameter, ParameterNode):
+        
+        if isinstance(parameters, ParameterNode):
+            for sub_parameter in parameters.children.values():
                 inflate_parameters(sub_parameter, inflator, base_year, last_year, ignore_missing_units = ignore_missing_units, 
                                    start_update_instant = start_update_instant, round_ndigits = round_ndigits)
-            else:
-                acceptable_units = [
-                    'rate_unit',
-                    'threshold_unit',
-                    'unit',
-                    ]
-                if ignore_missing_units:
-                    if not hasattr(sub_parameter, 'metadata'):
-                        continue
-                    # Empty intersection: not unit present in metadata
-                    if not bool(set(sub_parameter.metadata.keys()) & set(acceptable_units)):
-                        continue
-
-                assert hasattr(sub_parameter, 'metadata'), "{} doesn't have metadata".format(sub_parameter.name)
-                unit_types = set(sub_parameter.metadata.keys()).intersection(set(acceptable_units))
-                assert unit_types, "No admissible unit in metadata for parameter {}. You may consider using the option 'ignore_missing_units' from the inflate_paramaters() function.".format(
-                    sub_parameter.name)
-                if len(unit_types) > 1:
-                    assert unit_types == set(['threshold_unit', 'rate_unit']), \
-                        "Too much admissible units in metadata for parameter {}".format(
-                            sub_parameter.name)
-                unit_by_type = dict([
-                    (unit_type, sub_parameter.metadata[unit_type]) for unit_type in unit_types
-                    ])
-
-                for unit_type in unit_by_type.keys():
-                    if sub_parameter.metadata[unit_type].startswith("currency"):
-                        inflate_parameter_leaf(sub_parameter, base_year, inflator, unit_type = unit_type, start_update_instant = start_update_instant, round_ndigits = round_ndigits)
+        else:
+            acceptable_units = [
+                'rate_unit',
+                'threshold_unit',
+                'unit',
+                ]
+            if ignore_missing_units:
+                if not hasattr(parameters, 'metadata'):
+                    return
+                # Empty intersection: not unit present in metadata
+                if not bool(set(parameters.metadata.keys()) & set(acceptable_units)):
+                    return
+            assert hasattr(parameters, 'metadata'), "{} doesn't have metadata".format(parameters.name)
+            unit_types = set(parameters.metadata.keys()).intersection(set(acceptable_units))
+            assert unit_types, "No admissible unit in metadata for parameter {}. You may consider using the option 'ignore_missing_units' from the inflate_paramaters() function.".format(
+                parameters.name)
+            if len(unit_types) > 1:
+                assert unit_types == set(['threshold_unit', 'rate_unit']), \
+                    "Too much admissible units in metadata for parameter {}".format(
+                        parameters.name)
+            unit_by_type = dict([
+                (unit_type, parameters.metadata[unit_type]) for unit_type in unit_types
+                ])
+            for unit_type in unit_by_type.keys():
+                if parameters.metadata[unit_type].startswith("currency"):
+                    inflate_parameter_leaf(parameters, base_year, inflator, unit_type = unit_type, start_update_instant = start_update_instant, round_ndigits = round_ndigits)
 
 
 def inflate_parameter_leaf(sub_parameter, base_year, inflator, unit_type = 'unit', start_update_instant = None, round_ndigits = 2):

--- a/openfisca_survey_manager/utils.py
+++ b/openfisca_survey_manager/utils.py
@@ -13,25 +13,26 @@ log = logging.getLogger(__name__)
 
 
 def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore_missing_units = False,
-                       start_instant  = None, round_ndigits = 2):
+                       start_instant = None, round_ndigits = 2):
     """
     Inflate a Parameter node or a Parameter lead according for the years between base_year and last_year
     ::parameters:: af Parameter node or a Parameter leaf
     ::inflator:: rate used to inflate the parameter. The rate is unique for all the years
     ::base_year:: base year of the parameter
     ::last_year::  last year of inflation
-    ::ignore_missing_units:: if True, a parameter leaf without unit in metadata will not be inflate 
-    ::start_instant :: Instant of the year when the update should start, if None will be Junuary 1st  
+    ::ignore_missing_units:: if True, a parameter leaf without unit in metadata will not be inflate
+    ::start_instant :: Instant of the year when the update should start, if None will be Junuary 1st
     ::round_ndigits:: Number of digits to keep in the rounded result
     """
 
     if (last_year is not None) and (last_year > base_year + 1):
         for year in range(base_year + 1, last_year + 1):
-            # For each year we inflate with the same inflator rate. Example : 
+            # For each year we inflate with the same inflator rate. Example :
             # base_year + 1 : paramaters = paramaters * inflator
             # base_year + 2 : parameters = parameters * inflator * inflator
+
             inflate_parameters(parameters, inflator, year - 1, last_year = year, ignore_missing_units = ignore_missing_units,
-                               start_instant  = start_instant , round_ndigits = round_ndigits)
+                               start_instant = start_instant, round_ndigits = round_ndigits)
 
     else:
         if last_year is None:
@@ -42,7 +43,7 @@ def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore
         if isinstance(parameters, ParameterNode):
             for sub_parameter in parameters.children.values():
                 inflate_parameters(sub_parameter, inflator, base_year, last_year, ignore_missing_units = ignore_missing_units,
-                                   start_instant  = start_instant , round_ndigits = round_ndigits)
+                                   start_instant = start_instant, round_ndigits = round_ndigits)
         else:
             acceptable_units = [
                 'rate_unit',
@@ -68,17 +69,17 @@ def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore
                 ])
             for unit_type in unit_by_type.keys():
                 if parameters.metadata[unit_type].startswith("currency"):
-                    inflate_parameter_leaf(parameters, base_year, inflator, unit_type = unit_type, start_instant  = start_instant , round_ndigits = round_ndigits)
+                    inflate_parameter_leaf(parameters, base_year, inflator, unit_type = unit_type, start_instant = start_instant, round_ndigits = round_ndigits)
 
 
-def inflate_parameter_leaf(sub_parameter, base_year, inflator, unit_type = 'unit', start_instant  = None, round_ndigits = 2):
+def inflate_parameter_leaf(sub_parameter, base_year, inflator, unit_type = 'unit', start_instant = None, round_ndigits = 2):
     """
     Inflate a Parameter leaf according to unit type for the year after base_year
     ::sub_parameter:: af Parameter leaf
-    ::base_year:: base year of the parameter 
+    ::base_year:: base year of the parameter
     ::inflator:: rate used to inflate the parameter
     ::unit_type:: unit supposed by default. Other admissible unit types are threshold_unit and rate_unit
-    ::start_instant:: Instant of the year when the update should start, if None will be Junuary 1st  
+    ::start_instant:: Instant of the year when the update should start, if None will be Junuary 1st
     ::round_ndigits:: Number of digits to keep in the rounded result
     """
     if isinstance(sub_parameter, Scale):

--- a/openfisca_survey_manager/utils.py
+++ b/openfisca_survey_manager/utils.py
@@ -82,7 +82,7 @@ def inflate_parameter_leaf(sub_parameter, base_year, inflator, unit_type = 'unit
         if unit_type == 'threshold_unit':
             for bracket in sub_parameter.brackets:
                 threshold = bracket.children['threshold']
-                inflate_parameter_leaf(threshold, base_year, inflator)
+                inflate_parameter_leaf(threshold, base_year, inflator, start_instant = start_instant, round_ndigits = round_ndigits)
             return
     else:
         # Remove new values for year > base_year

--- a/openfisca_survey_manager/utils.py
+++ b/openfisca_survey_manager/utils.py
@@ -26,11 +26,7 @@ def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore
     """
 
     if (last_year is not None) and (last_year > base_year + 1):
-        for year in range(base_year + 1, last_year + 1):
-            # For each year we inflate with the same inflator rate. Example :
-            # base_year + 1 : paramaters = paramaters * inflator
-            # base_year + 2 : parameters = parameters * inflator * inflator
-
+        for year in range(base_year + 1, last_year + 1): # For each year we inflate with the same inflator rate. Example : base_year + 1 : paramaters = paramaters * inflator ; base_year + 2 : parameters = parameters * inflator * inflator
             inflate_parameters(parameters, inflator, year - 1, last_year = year, ignore_missing_units = ignore_missing_units,
                                start_instant = start_instant, round_ndigits = round_ndigits)
 

--- a/openfisca_survey_manager/utils.py
+++ b/openfisca_survey_manager/utils.py
@@ -12,12 +12,12 @@ from openfisca_core.parameters import ParameterNode, Scale
 log = logging.getLogger(__name__)
 
 
-def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore_missing_units = False, 
+def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore_missing_units = False,
                        start_update_instant = None, round_ndigits = 2):
 
     if (last_year is not None) and (last_year > base_year + 1):
         for year in range(base_year + 1, last_year + 1):
-            inflate_parameters(parameters, inflator, year - 1, last_year = year, ignore_missing_units = ignore_missing_units, 
+            inflate_parameters(parameters, inflator, year - 1, last_year = year, ignore_missing_units = ignore_missing_units,
                                start_update_instant = start_update_instant, round_ndigits = round_ndigits)
 
     else:
@@ -25,10 +25,10 @@ def inflate_parameters(parameters, inflator, base_year, last_year = None, ignore
             last_year = base_year + 1
 
         assert last_year == base_year + 1
-        
+
         if isinstance(parameters, ParameterNode):
             for sub_parameter in parameters.children.values():
-                inflate_parameters(sub_parameter, inflator, base_year, last_year, ignore_missing_units = ignore_missing_units, 
+                inflate_parameters(sub_parameter, inflator, base_year, last_year, ignore_missing_units = ignore_missing_units,
                                    start_update_instant = start_update_instant, round_ndigits = round_ndigits)
         else:
             acceptable_units = [
@@ -87,7 +87,7 @@ def inflate_parameter_leaf(sub_parameter, base_year, inflator, unit_type = 'unit
             value = sub_parameter(last_admissible_instant_str)
             )
         if start_update_instant is not None:
-            assert periods.instant(start_update_instant).year == (base_year + 1), "Year of start_update_instant should be base_year + 1"     
+            assert periods.instant(start_update_instant).year == (base_year + 1), "Year of start_update_instant should be base_year + 1"
             value = (
                 round(sub_parameter("{}-12-31".format(base_year)) * (1 + inflator), round_ndigits)
                 if sub_parameter("{}-12-31".format(base_year)) is not None

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '1.0.3',
+    version = '1.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '1.0.2',
+    version = '1.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### New features

- Add options in `inflate_parameters` and `inflate_parameter_leaf`:
  - `start_update_instant` : Instant of the year when the inflation should start, if different from January 1st
  - `round_ndigits` : number of digits in the rounded result
- Adjustment of `inflate_parameters` to use it with parameter leaf.  
