### PR TITLE
Open hdf in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,24 @@
 ﻿# Changelog
 
+### 1.1.6 [#269](https://github.com/openfisca/openfisca-survey-manager/pull/269)
+
+* Technical changes
+  - HDF files are now opened in read-only mode to prevent locking when multiple survey-manager need to access the same file.
 
 ### 1.1.5 [#265](https://github.com/openfisca/openfisca-survey-manager/pull/265)
 
 * Technical changes
-- Use `find_namespace_packages` and instead of `find_packages` in `setup.py`
+  - Use `find_namespace_packages` and instead of `find_packages` in `setup.py`
 
 ### 1.1.4 [#264](https://github.com/openfisca/openfisca-survey-manager/pull/264)
 
 * Technical changes
-- Change importlib metadata import to work with all Python version
+  - Change importlib metadata import to work with all Python version
 
 ### 1.1.3 [#263](https://github.com/openfisca/openfisca-survey-manager/pull/263)
 
 * Technical changes
-- Use importlib instead of pkg_resources to avoid deprecation warnings
+  - Use importlib instead of pkg_resources to avoid deprecation warnings
 
 ### 1.1.2 [#262](https://github.com/openfisca/openfisca-survey-manager/pull/262)
 

--- a/openfisca_survey_manager/scenarios.py
+++ b/openfisca_survey_manager/scenarios.py
@@ -256,7 +256,7 @@ class AbstractSurveyScenario(object):
                         f"{alternative_weights} is not a valid variable of the tax benefit system"
                     weight_variable = alternative_weights
 
-                elif type(alternative_weights) == int or type(alternative_weights) == float:
+                elif isinstance(alternative_weights, int) or isinstance(alternative_weights, float):
                     weight_variable = None
                     uniform_weight = float(alternative_weights)
 
@@ -437,7 +437,7 @@ class AbstractSurveyScenario(object):
                         f"{alternative_weights} is not a valid variable of the tax benefit system"
                     weight_variable = alternative_weights
 
-                elif type(alternative_weights) == int or type(alternative_weights) == float:
+                elif isinstance(alternative_weights, int) or isinstance(alternative_weights, float):
                     weight_variable = None
                     uniform_weight = float(alternative_weights)
 

--- a/openfisca_survey_manager/surveys.py
+++ b/openfisca_survey_manager/surveys.py
@@ -131,7 +131,7 @@ Contains the following tables : \n""".format(self.name, self.label)
 
     def get_columns(self, table = None, rename_ident = True):
         assert table is not None
-        store = pandas.HDFStore(self.hdf5_file_path)
+        store = pandas.HDFStore(self.hdf5_file_path, "r")
         if table in store:
             log.debug("Building columns index for table {}".format(table))
             data_frame = store[table]
@@ -183,7 +183,7 @@ Contains the following tables : \n""".format(self.name, self.label)
         assert self.hdf5_file_path is not None
         assert os.path.exists(self.hdf5_file_path), '{} is not a valid path. This could happen because your data were not builded yet. Please consider using a rebuild option in your code.'.format(
             self.hdf5_file_path)
-        store = pandas.HDFStore(self.hdf5_file_path)
+        store = pandas.HDFStore(self.hdf5_file_path, "r")
 
         if ignorecase:
             keys = store.keys()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '1.1.5',
+    version = '1.1.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### Technical changes

- HDF files is now read in read-only mode to prevent locking when multiple survey-manager need to access the same file.
