### PR TITLE
Fix entities ids columns in merge create_data_frame_by_entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ﻿# Changelog
 
+# 2.0.1 [#279](https://github.com/openfisca/openfisca-survey-manager/pull/279)
+
+#### Technical changes
+
+- Fix names of ids columns when the merge option is True in create_data_frame_by_entity.
+
 # 2.0.O [#273](https://github.com/openfisca/openfisca-survey-manager/pull/273)
 
 #### Breaking changes

--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -598,7 +598,7 @@ def create_data_frame_by_entity(simulation: Simulation, variables: Optional[List
         for entity in non_person_entities:
             entity_key_id = id_variable_by_entity_key[entity.key]
             person_data_frame[
-                "{}_{}".format(entity.key, 'id')
+                entity_key_id
                 ] = simulation.populations[entity.key].members_entity_id
             flattened_roles = entity.flattened_roles
             index_by_role = dict(
@@ -634,12 +634,12 @@ def create_data_frame_by_entity(simulation: Simulation, variables: Optional[List
     else:
         for entity_key, openfisca_data_frame in openfisca_data_frame_by_entity_key.items():
             if entity_key != person_entity.key:
-                openfisca_data_frame.index.name = '{}_id'.format(entity_key)
-                if len(openfisca_data_frame.reset_index()) > 0:
+                entity_key_id = id_variable_by_entity_key[entity.key]
+                if len(openfisca_data_frame) > 0:
                     person_data_frame = person_data_frame.merge(
                         openfisca_data_frame.reset_index(),
-                        left_on = '{}_id'.format(entity_key),
-                        right_on = '{}_id'.format(entity_key),
+                        left_on = entity_key_id,
+                        right_on = entity_key_id,
                         )
         return person_data_frame
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '2.0.0',
+    version = '2.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### Technical changes

- Fix names of ids columns when the merge option is True in `create_data_frame_by_entity`.
The code didn't work when the name of the ids was the default ids name `entity_id`. 
