### PR TITLE
Améliore la gestion des poids dans compute_aggregate

### DIFF
--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -184,18 +184,17 @@ def compute_aggregate(simulation: Simulation, variable: str = None, aggfunc: str
     if variable in simulation.tax_benefit_system.variables:
         value = simulation.adaptative_calculate_variable(variable = variable, period = period)
     else:
-        log.debug("Variable {} not found. Assiging {}".format(variable, missing_variable_default_value))
+        log.debug("Variable {} not found. Assigning {}".format(variable, missing_variable_default_value))
         return missing_variable_default_value
 
     # The following lines allow for under-yearly weighted aggregates even if weights are annual
-    period_size_independent_weight = tax_benefit_system.get_variable(weight_variable).is_period_size_independent
-    definition_period_weight = tax_benefit_system.get_variable(weight_variable).definition_period
-    if not isinstance(period, periods.Period):
-        period = periods.period(str(period))
-    if period_size_independent_weight is True and definition_period_weight == 'year' and period.start.year == period.stop.year:
-        period_computation_weights = period.this_year
-    else:
-        period_computation_weights = period
+    if weighted and weight_variable is not None:
+        period_size_independent_weight = tax_benefit_system.get_variable(weight_variable).is_period_size_independent
+        definition_period_weight = tax_benefit_system.get_variable(weight_variable).definition_period
+        if not isinstance(period, periods.Period):
+            period = periods.period(str(period))
+        if period_size_independent_weight is True and definition_period_weight == 'year' and period.start.year == period.stop.year:
+            period_computation_weights = period.this_year
 
     weight = (
         simulation.calculate(weight_variable, period = period_computation_weights).astype(float)

--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -187,8 +187,18 @@ def compute_aggregate(simulation: Simulation, variable: str = None, aggfunc: str
         log.debug("Variable {} not found. Assiging {}".format(variable, missing_variable_default_value))
         return missing_variable_default_value
 
+    # The following lines allow for under-yearly weighted aggregates even if weights are annual
+    period_size_independent_weight = tax_benefit_system.get_variable(weight_variable).is_period_size_independent
+    definition_period_weight = tax_benefit_system.get_variable(weight_variable).definition_period
+    if not isinstance(period, periods.Period):
+        period = periods.period(str(period))
+    if period_size_independent_weight is True and definition_period_weight == 'year' and period.start.year == period.stop.year:
+        period_computation_weights = period.this_year
+    else:
+        period_computation_weights = period
+    
     weight = (
-        simulation.calculate(weight_variable, period = period).astype(float)
+        simulation.calculate(weight_variable, period = period_computation_weights).astype(float)
         if weight_variable else uniform_weight
         )
     if weight_variable:

--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -196,7 +196,7 @@ def compute_aggregate(simulation: Simulation, variable: str = None, aggfunc: str
         period_computation_weights = period.this_year
     else:
         period_computation_weights = period
-    
+
     weight = (
         simulation.calculate(weight_variable, period = period_computation_weights).astype(float)
         if weight_variable else uniform_weight

--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -195,6 +195,10 @@ def compute_aggregate(simulation: Simulation, variable: str = None, aggfunc: str
             period = periods.period(str(period))
         if period_size_independent_weight is True and definition_period_weight == 'year' and period.start.year == period.stop.year:
             period_computation_weights = period.this_year
+        else:
+            period_computation_weights = period
+    else:
+        period_computation_weights = period
 
     weight = (
         simulation.calculate(weight_variable, period = period_computation_weights).astype(float)


### PR DESCRIPTION
Autorise dans `compute_aggregate` des agrégats pondérés infra-annuels quand les poids sont annuels.