### PR TITLE
Fix check-version-and-changelog stop working properly #288

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -10,6 +10,5 @@ if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNO
 then
   echo "No functional changes detected."
   exit 1
-else
-  echo "The functional files above were changed."
+else echo "The functional files above were changed."
 fi

--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -14,3 +14,4 @@ then
   exit 1
 fi
 echo "The functional files above were changed."
+exit 0

--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -6,9 +6,11 @@ IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/* .conda/*
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 
+echo "Last tagged commit: $last_tagged_commit"
+
 if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
 then
   echo "No functional changes detected."
   exit 1
-else echo "The functional files above were changed."
 fi
+echo "The functional files above were changed."

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -70,7 +70,6 @@ jobs:
     env:
       # Needed for coveralls
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -89,30 +88,6 @@ jobs:
         run: make test
       - name : coverage
         run: coveralls --service=github
-
-  # Coverage will need GITHUB_TOKEN : "Running on Github Actions but GITHUB_TOKEN is not set."
-  # coverage:
-  #   runs-on: ${{ matrix.os }}
-  #   needs: [ build ]
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       os: [ "ubuntu-20.04" ]  # On peut ajouter "macos-latest" si besoin
-  #       python-version: ["3.9.9"]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Cache build
-  #       id: restore-build
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: ${{ env.pythonLocation }}
-  #         key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}
-  #     - name : coverage
-  #       run: coveralls
 
   check-version-and-changelog:
     runs-on: ubuntu-20.04

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,14 +15,14 @@ jobs:
         python-version: ["3.9.9", "3.10.6"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}
@@ -33,7 +33,7 @@ jobs:
         run: make build
       - name: Cache release
         id: restore-release
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}
@@ -42,16 +42,16 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [ build ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04
@@ -72,14 +72,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}
@@ -100,14 +100,14 @@ jobs:
   #       os: [ "ubuntu-20.04" ]  # On peut ajouter "macos-latest" si besoin
   #       python-version: ["3.9.9"]
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v4
   #     - name: Set up Python
   #       uses: actions/setup-python@v3
   #       with:
   #         python-version: ${{ matrix.python-version }}
   #     - name: Cache build
   #       id: restore-build
-  #       uses: actions/cache@v3
+  #       uses: actions/cache@v4
   #       with:
   #         path: ${{ env.pythonLocation }}
   #         key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-${{ matrix.os }}
@@ -118,11 +118,11 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [ lint-files, build ] # TODO: Replace build by test-python
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Check version number has been properly updated
@@ -138,11 +138,11 @@ jobs:
     outputs:
       status: ${{ steps.stop-early.outputs.has_functional_changes_status }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - id: stop-early
@@ -156,22 +156,22 @@ jobs:
       PYPI_USERNAME: openfisca-bot
       PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9.9
       - name: Cache build
         id: restore-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04
       - name: Cache release
         id: restore-release
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04
@@ -191,7 +191,7 @@ jobs:
           # Add openfisca channel for OpenFisca-Core
           channels: conda-forge, openfisca
           activate-environment: true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Conda config
@@ -214,7 +214,7 @@ jobs:
           # Add openfisca channel for OpenFisca-Core
           channels: conda-forge, openfisca
           activate-environment: true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all the tags
       - name: Install with conda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ﻿# Changelog
 
+# 2.0.6 [#291](https://github.com/openfisca/openfisca-survey-manager/pull/291)
+
+* Technical changes
+  - Fix the script check-version-and-changelog.sh to fix issue #288
+  - Upgrade CI actions
+
+# 2.0.5 [#286](https://github.com/openfisca/openfisca-survey-manager/pull/286)
+
+* New features
+  - Allows sub-annual weighted aggregates in compute_aggregate when the weights are annual.
+
 # 2.0.4 [#283](https://github.com/openfisca/openfisca-survey-manager/pull/283)
 
 - Correction function compute_pivot_tables in ReformScenario

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '2.0.4',
+    version = '2.0.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
* Technical changes
  - Fix the script check-version-and-changelog.sh to fix issue #288
  - Upgrade CI actions versions to avoid "Node 16" warning