### PR TITLE
Replace warning by assertion for no weights if weighted is True for compute_aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 2.2.1 [#298](https://github.com/openfisca/openfisca-survey-manager/pull/298)
+
+* For `compute_aggregate`, replace the warning by an assert when `weighted = True` (the default) and no weight is defined for the variable. Before, a warning was displayed and the aggregate was computed using uniform weights.
+
 ## 2.2.0 [#295](https://github.com/openfisca/openfisca-survey-manager/pull/295)
 
 * Improve support for parquet file format :

--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -2,6 +2,7 @@
 
 import logging
 import numpy as np
+from numpy import logical_or as or_
 import pandas as pd
 import re
 from typing import Callable, Dict, List, Optional, Union
@@ -165,6 +166,7 @@ def compute_aggregate(simulation: Simulation, variable: str = None, aggfunc: str
     uniform_weight = np.array(1.0)
     weight_variable = None
     if weighted:
+        assert or_(alternative_weights, weight_variable_by_entity), "The weighted option is set at True but there is no weight variable for entity {} nor alternative weights. Either define a weight variable or switch to unweighted".format(entity_key)
         if alternative_weights:
             if isinstance(alternative_weights, str):
                 assert alternative_weights in tax_benefit_system.variables, \
@@ -174,13 +176,8 @@ def compute_aggregate(simulation: Simulation, variable: str = None, aggfunc: str
             elif (type(alternative_weights) is int) or (type(alternative_weights) is float):
                 weight_variable = None
                 uniform_weight = float(alternative_weights)
-
-        else:
-            if weight_variable_by_entity:
-                weight_variable = weight_variable_by_entity[entity_key]
-
-            else:
-                log.warn('There is no weight variable for entity {} nor alternative weights. Switch to unweighted'.format(entity_key))
+        elif weight_variable_by_entity:
+            weight_variable = weight_variable_by_entity[entity_key]
 
     if variable in simulation.tax_benefit_system.variables:
         value = simulation.adaptative_calculate_variable(variable = variable, period = period)

--- a/openfisca_survey_manager/tests/test_compute_aggregate.py
+++ b/openfisca_survey_manager/tests/test_compute_aggregate.py
@@ -19,14 +19,12 @@ def test_compute_aggregate():
         "social_security_contribution",
         period = period,
         filter_by = "salary < 3000",
-        weighted = False,
         )
 
     assert 34489 == survey_scenario.compute_aggregate(
         "social_security_contribution",
         period = period,
         filter_by = "3000 < salary < 10000",
-        weighted = False,
         ).astype(int)
 
     del survey_scenario.weight_variable_by_entity

--- a/openfisca_survey_manager/tests/test_compute_aggregate.py
+++ b/openfisca_survey_manager/tests/test_compute_aggregate.py
@@ -19,12 +19,14 @@ def test_compute_aggregate():
         "social_security_contribution",
         period = period,
         filter_by = "salary < 3000",
+        weighted = False,
         )
 
     assert 34489 == survey_scenario.compute_aggregate(
         "social_security_contribution",
         period = period,
         filter_by = "3000 < salary < 10000",
+        weighted = False,
         ).astype(int)
 
     del survey_scenario.weight_variable_by_entity
@@ -33,4 +35,5 @@ def test_compute_aggregate():
         "social_security_contribution",
         period = period,
         filter_by = "3000 < salary < 10000",
+        weighted = False,
         ).astype(int)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '2.2.0',
+    version = '2.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
Aims at solving #287 : for `compute_aggregate`, replace the warning by an assert when `weighted = True` (the default) and no weight is defined for the variable. Before, a warning was displayed and the aggregate was computed using uniform weights.