### PR TITLE
Solve issue calmar target_entity_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ﻿# Changelog
 
-### 2.3.2 [#319](https://github.com/openfisca/openfisca-survey-manager/pull/315)
+### 2.3.3 [#316](https://github.com/openfisca/openfisca-survey-manager/pull/315)
+
+* Technical changes
+  - Solve an issue caused by #299 when there is a target_entity_count without variables of the same entity.
+  - Correct the CHANGELOG which had two errors.
+
+
+### 2.3.2 [#315](https://github.com/openfisca/openfisca-survey-manager/pull/315)
 
 * Technical changes
   - Transform input arrays of Enums variables in EnumArray type to improve computation speed due to changes in Openfisca-core 42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-### 3.3.2 [#319](https://github.com/openfisca/openfisca-survey-manager/pull/315)
+### 2.3.2 [#319](https://github.com/openfisca/openfisca-survey-manager/pull/315)
 
 * Technical changes
   - Transform input arrays of Enums variables in EnumArray type to improve computation speed due to changes in Openfisca-core 42
@@ -11,7 +11,7 @@
   - Add a new distance function method, the hyperbolic sinus. It allows to cap the weight ratio with a one dimensionnal parametring, and with less computation issues than with the logit method.
   - It is described in Calmar 2 documentation
 
-## 2.3.0 [#308](https://github.com/openfisca/openfisca-survey-manager/pull/308)
+## 2.3.0 [#299](https://github.com/openfisca/openfisca-survey-manager/pull/299)
 
 * New features
   - Allows for calibration of variables defined in two different entities ; it requires that one is included in the other (ex : individuals and fiscal household : each individual is in only one fiscal household). To use it, a variable identifying in the smaller entity the identifier of the larger one is needed (the name must be given in parameter "id_variable_link").

--- a/openfisca_survey_manager/calibration.py
+++ b/openfisca_survey_manager/calibration.py
@@ -244,13 +244,14 @@ class Calibration(object):
         simulation = self.simulation
         simulation.set_input(self.weight_name, period, self.weight)
         for weight_name in simulation.weight_variable_by_entity.values():
+            weight_variable = simulation.tax_benefit_system.variables[weight_name]
             if weight_name == self.weight_name:
-                weight_variable = simulation.tax_benefit_system.variables[weight_name]
                 weight_variable.unit = "base_weight"  # The weight variable is flagged as the one that have changed
+                if weight_variable.formulas:
+                    weight_variable.formulas = []  # The weight variable becomes an input variable after it changes with calibration
             # Delete other entites already computed weigths
             # to ensure that this weights a recomputed if they derive from
             # the calibrated weight variable
-            weight_variable = simulation.tax_benefit_system.variables[weight_name]
             if weight_variable.formulas:
                 simulation.delete_arrays(weight_variable.name, period)
 

--- a/openfisca_survey_manager/calibration.py
+++ b/openfisca_survey_manager/calibration.py
@@ -54,6 +54,8 @@ class Calibration(object):
             variable_instance_by_variable_name[variable].entity.key
             for variable in margin_variables
             )
+        if entity is not None:
+            entities.add(entity)
         self.entities = list(entities)
 
         if len(entities) == 0:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Survey-Manager',
-    version = '2.3.2',
+    version = '2.3.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
#### Technical changes

- Solve an issue caused by [#299](https://github.com/openfisca/openfisca-survey-manager/pull/299) when there is a target_entity_count without variables of the same entity.
- Correct the CHANGELOG which had two errors.
- Correct a problem of circular definition by erasing the formula of a weight variable after it is recomputed using calmar.
