### PR TITLE
comment out the encoding arg for the stata reader

### DIFF
--- a/openfisca_survey_manager/tables.py
+++ b/openfisca_survey_manager/tables.py
@@ -213,10 +213,11 @@ class Table(object):
                         kwargs['dialect'] = dialect
                     else:
                         kwargs['delimiter'] = delimiter
-                    kwargs['encoding'] = encoding
                     data_frame = reader(data_file, **kwargs)
 
             else:
+                if source_format == "stata":
+                    del kwargs['encoding']
                 data_frame = reader(data_file, **kwargs)
 
         except Exception as e:


### PR DESCRIPTION
Thanks for contributing to OpenFisca-Survey-Manager! Remove this line, as well as any other in the following that don't fit your contribution  :)

#### Technical changes

- Remove an argument passed to the `read_source` function when the source is dta format, because the stata reader does not accept the argument
