### PR TITLE
Fix incomplete enum generation

### DIFF
--- a/openfisca_survey_manager/simulations.py
+++ b/openfisca_survey_manager/simulations.py
@@ -1080,16 +1080,11 @@ def init_variable_in_entity(simulation: Simulation, entity, variable_name, serie
                 variable_name, variable.default_value._name_))
             series.fillna(variable.default_value._name_, inplace = True)
         possible_values = variable.possible_values
-        # index_by_category = dict(zip(
-        #     possible_values._member_names_,
-        #     range(len(possible_values._member_names_))
-        #     ))
-
         if isinstance(series.dtype, pd.CategoricalDtype):
             series = series.cat.codes
         else:
             assert series.isin(list(possible_values._member_names_)).all()
-            series = series.astype("category").cat.codes
+            series = series.apply(lambda v: variable.possible_values[v].index)
 
     if series.values.dtype != variable.dtype:
         log.debug(

--- a/openfisca_survey_manager/tests/test_enum.py
+++ b/openfisca_survey_manager/tests/test_enum.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from openfisca_country_template.variables.housing import HousingOccupancyStatus
+from openfisca_survey_manager.tests import tax_benefit_system
+from openfisca_core import periods
+from openfisca_core.simulations import Simulation
+from openfisca_core.simulations.simulation_builder import SimulationBuilder
+
+
+from openfisca_survey_manager.scenarios.abstract_scenario import AbstractSurveyScenario
+import openfisca_survey_manager.simulations
+import openfisca_survey_manager.simulation_builder
+
+
+def test_generation():
+    survey_scenario = AbstractSurveyScenario()
+    survey_scenario.set_tax_benefit_systems(dict(baseline = tax_benefit_system))
+    survey_scenario.period = "2025-06"
+    survey_scenario.used_as_input_variables = ['housing_occupancy_status']
+
+    statuses = [HousingOccupancyStatus.free_lodger, HousingOccupancyStatus.tenant]
+    data = { "input_data_frame": pd.DataFrame({
+        "housing_occupancy_status": pd.Series([v.name for v in statuses]),
+        "household_id": [0, 1],
+        "household_role_index": [0, 0]
+    })
+    }
+    survey_scenario.init_from_data(data=data)
+    result = survey_scenario.calculate_variable("housing_occupancy_status", survey_scenario.period)
+    assert ((result == pd.Series([v.index for v in statuses])).all())


### PR DESCRIPTION
#### Fix

Enum manipulation was broken and I struggle to understand how a bug was not discovered earlier.
`series.astype("category")` was dangerous as it completely ignores Enum members order.


I try to find an efficient way of generating those Enum array but I ended up with this `lambda` function.